### PR TITLE
refactor: remove destructuring while using useSelector hook

### DIFF
--- a/src/components/screens/main/questions/Questions.js
+++ b/src/components/screens/main/questions/Questions.js
@@ -34,12 +34,10 @@ const Questions = ({ LOCAL_STACK_ROUTES, navigation }: Props) => {
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [selectedAnswer, setSelectedAnswer] = useState('');
   const [userAnswers, setUserAnswers] = useState([]);
-
-  const {
-    loading, noResult, error, data,
-  } = useSelector(
-    (state) => state.questions,
-  );
+  const loading = useSelector((state) => state.questions.loading);
+  const noResult = useSelector((state) => state.questions.noResult);
+  const error = useSelector((state) => state.questions.error);
+  const data = useSelector((state) => state.questions.data);
 
   const questionsListRef: QuestionListRef = useRef(null);
   const dispatch = useDispatch();

--- a/src/components/screens/main/results/Results.js
+++ b/src/components/screens/main/results/Results.js
@@ -20,7 +20,8 @@ type Props = {
 };
 
 const Results = ({ navigation }: Props) => {
-  const { data, scores } = useSelector((state) => state.results);
+  const data = useSelector((state) => state.results.data);
+  const scores = useSelector((state) => state.results.scores);
   const dispatch = useDispatch();
 
   useEffect(() => {


### PR DESCRIPTION
**description:** If you will access entire reducer and de-structure in the component, basically you are registering your component to listen to entire reducer, so if any part of the reducer is changed, which you are not using in the component, your component will be forced to re render

checkout this [example](https://codesandbox.io/embed/sad-wave-mgl0t)
click on the button and see for yourself in console that the entire component is re rendering even through the part of the state which is changing is not used in the component while destructing 